### PR TITLE
900-cleanup-etc-var: move /etc/bindresvport.blacklist out

### DIFF
--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -28,3 +28,7 @@ rm -f /etc/mke2fs.conf
 
 # FIXME: undo all symlinks to /etc/alternatives and replace with their real
 # counterparts.
+
+
+# needs https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1736744
+mv /etc/bindresvport.blacklist /usr/share/libc6-bin/


### PR DESCRIPTION
This moves /etc/bindresvport.blacklist to /usr/share/libc6-bin.

Note that this needs
https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1736744 to be
applied in libc6