### PR TITLE
hooks,tests: mask motd timer/services

### DIFF
--- a/hooks/600-no-motd.chroot
+++ b/hooks/600-no-motd.chroot
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -eux
+
+systemctl mask motd-news.service
+systemctl mask motd-news.timer
+systemctl mask motd.service

--- a/tests/main/motd/task.yaml
+++ b/tests/main/motd/task.yaml
@@ -1,0 +1,5 @@
+summary: Ensure that dynamic motd update service/timer is disabled
+execute: |
+    systemctl list-unit-files | MATCH "motd-news.service +masked"
+    systemctl list-unit-files | MATCH "motd-news.timer +masked"
+    systemctl list-unit-files | MATCH "motd.service +masked"


### PR DESCRIPTION
NOTE: Ideally this would be done with a vendor preset. This would allow
us to not have a file in /etc and still have the same effect (the
services are not started).

Signed-off-by: Zygmunt Krynicki <zygmunt.krynicki@canonical.com>