### PR TITLE
tests/lib: ensure kernel is readable by the user

### DIFF
--- a/tests/lib/Makefile
+++ b/tests/lib/Makefile
@@ -103,4 +103,5 @@ core-snap/boot/initrd.img-core: core.snap
 kernel-snap/kernel.img: pc-kernel.snap
 	rm -rf kernel-snap
 	unsquashfs -dest kernel-snap -no-progress "$^" '/kernel.img' >/dev/null
+	sudo chmod 0644 "$^"
 	touch "$@"


### PR DESCRIPTION
Trivial PR, kernel is owned by root:root and mode 0600 in my fresh run.