### PR TITLE
hooks: fixes to make it usable as a real base snap

### DIFF
--- a/hooks/20-extra-files.chroot
+++ b/hooks/20-extra-files.chroot
@@ -14,3 +14,7 @@ echo "creating fontconfig mount points" >&2
 mkdir -p /usr/share/fonts
 mkdir -p /usr/local/share/fonts
 mkdir -p /var/cache/fontconfig
+
+echo "creating snap dirs/files"
+mkdir -p /snap /var/snap
+mkdir -p /usr/lib/snapd

--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -28,3 +28,7 @@ rm -f /etc/mke2fs.conf
 
 # FIXME: undo all symlinks to /etc/alternatives and replace with their real
 # counterparts.
+#
+# remove all alternatives for now to unbreak this snap, but replace this with
+# "unwinding" them
+rm -rf /etc/alternatives


### PR DESCRIPTION
Some directories that snapd wants to bind mount are currently missing and are added now.

There is also /etc/alternatives - snap-confine wants to bind mount this on classic but the current apparmor rules only allow this for core and ubuntu-core. We have two alternatives (sic) here:
1. allow snap-confine to bind mount /etc/alternatives
1. unwind /etc/alternatives

I am in favour of (2) because /etc/alternatives feels very strange on a read-only system. But this needs to be done still and while its missing things will work but some of the alternatives there (like awk) will be broken in base.