### PR TITLE
hooks: also install the disto-info package in base-18

### DIFF
--- a/hooks/00-extra-packages.chroot
+++ b/hooks/00-extra-packages.chroot
@@ -3,4 +3,4 @@ set -eux
 
 apt update
 apt dist-upgrade -y
-apt install -y systemd libnss-extrausers
+apt install -y systemd libnss-extrausers distro-info


### PR DESCRIPTION
This make the bionic maas snap work that uses base-18 - however I'm bit reluctant to add this package to the base-18 as this is a slippery slope. OTOH its really tiny.