### PR TITLE
ensure hook failures make snapcraft fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,11 @@ all: check
 install: DESTDIR?=$(error you must set DESTDIR)
 install:
 	debootstrap --variant=minbase bionic $(DESTDIR)
-	set -ex; for f in ./hooks/[0-9]*; do \
+	set -ex; for f in ./hooks/[0-9]*.chroot; do \
 		cp -a $$f $(DESTDIR)/tmp && \
-		chroot $(DESTDIR) /tmp/$$(basename $$f) && \
+		if ! chroot $(DESTDIR) /tmp/$$(basename $$f); then \
+                    exit 1; \
+                fi && \
 		rm -f $(DESTDIR)/tmp/$$(basename $$f); \
 	done;
 	# only generate manifest file for lp build

--- a/hooks/00-extra-packages.chroot
+++ b/hooks/00-extra-packages.chroot
@@ -1,6 +1,15 @@
 #!/bin/sh
+
 set -eux
 
+# ensure we have /proc or systemd will fail
+mount -t proc proc /proc
+trap 'umount /proc' EXIT
+
+# systemd postinst needs this
+mkdir -p /var/log/journal
+
+# install some packages we need
 apt update
 apt dist-upgrade -y
-apt install -y systemd libnss-extrausers
+apt install --no-install-recommends -y systemd libnss-extrausers

--- a/hooks/40-remove-pkgs.chroot
+++ b/hooks/40-remove-pkgs.chroot
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+echo "Remove uneeded packages"
+dpkg -r debconf dh-python e2fsprogs fdisk gpgv  libdebconfclient0


### PR DESCRIPTION
And one unrelated change: remove some extra packages (dh-python).