### PR TITLE
900-cleanup-etc-var.chroot: unwind /etc/alternatives

### DIFF
--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -56,11 +56,17 @@ rmdir /etc/cron.daily
 # no need for emtpy dirs
 rmdir /etc/dbus-1/session.d /etc/dbus-1/system.d
 
-# FIXME: undo all symlinks to /etc/alternatives and replace with their real
-# counterparts.
+# undo all symlinks to /etc/alternatives and replace with their real
+# counterparts. The alternatives system looks like this:
 #
-# remove all alternatives for now to unbreak this snap, but replace this with
-# "unwinding" them
-rm -rf /etc/alternatives
+# /usr/bin/pager -> /etc/alternatives/pager -> /bin/more
+#
+find /etc/alternatives -type l | while read -r f; do
+    real=$(readlink -f "$f")
+    alias=$(dirname "$real")/$(basename "$f")
+    rm -f "$alias"
+    ln -s "$real" "$alias"
+done
+
 
 # FIXME: make /etc/lsb-release point to ../usr/lib/lsb-release


### PR DESCRIPTION
Some binaries (like /usr/bin/awk) are represented using the
"alternatives" system in debian. This means that awk is a
symlink into /etc/alternatives which then points to the
awk implementation to use:

    /usr/bin/awk -> /etc/alternatives/awk -> /usr/bin/mawk

This PR removes the middle link into /etc to make /etc clean(er):

   /usr/bin/awk -> /usr/bin/mawk