### PR TITLE
hooks: add basic systemd factory reset

### DIFF
--- a/hooks/50-tmpfiles-d.chroot
+++ b/hooks/50-tmpfiles-d.chroot
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -e
+
+cat > /usr/lib/tmpfiles.d/00-ubuntu-core.conf <<EOF
+# Type Path                Mode UID  GID   Age  Argument
+d      /snap               0755 root root  -    -
+d      /var/snap           0755 root root  -    -
+d      /var/lib/snapd      0755 root root  -    -
+
+C      /etc/passwd         -    -    -     -    -
+C      /etc/group          -    -    -     -    -
+C      /etc/shadow         -    -    -     -    -
+C      /etc/gshadow        -    -    -     -    -
+C      /etc/nsswitch.conf  -    -    -     -    -
+C      /etc/pam.d          -    -    -     -    -
+C      /etc/login.defs     -    -    -     -    -
+C      /etc/security       -    -    -     -    -
+C      /etc/sudoers        -    -    -     -    -
+
+L      /etc/resolv.conf    -    -    -     -    ../run/systemd/resolve/stub-resolv.conf
+
+d     /var/tmp             1777 root root  -
+d     /var/lib/dbus        0755 root root  -
+EOF

--- a/hooks/60-factory.chroot
+++ b/hooks/60-factory.chroot
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+mkdir -p /usr/share/factory/etc
+
+for p in passwd group shadow gshadow nsswitch.conf pam.d sudoers login.defs; do
+    cp -a /etc/$p /usr/share/factory/etc
+done
+
+
+mkdir -p /usr/share/factory/etc/security
+cp -a /etc/security/limits.conf /usr/share/factory/etc/security/


### PR DESCRIPTION
This creates template files in /usr/share/factory/etc and makes
a new /usr/lib/tmpfile.d/00-ubuntu-core.conf that copies the
files in place.

The boot with empty /etc and /var can be tested with:
$ sudo systemd-nspawn -D ./prime/ --read-only --tmpfs=/var --tmpfs=/etc -b -
[mess around]
$ sudo machinectl terminate prime